### PR TITLE
Account for fieldname diff in non-default config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Builds the container.
 
-CONTAINER=scitran/dcm-convert
+CONTAINER=scitran/dcm-convert:v1.1.0
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 docker build --no-cache --tag $CONTAINER $DIR

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
 	"source": "https://github.com/scitran-apps/dcm-convert",
 	"license":  "Apache-2.0",
 	"flywheel": "0",
-	"version":  "1.0.0",
+	"version":  "1.1.0",
 	"config": {
 		"convert_montage": {
 				"description": "Convert selected DICOM archive to MONTAGE format. (Default=true)",
@@ -34,6 +34,6 @@
 		}
 	},
 	"custom": {
-		"docker-image": "scitran/dcm-convert:v1.0.0"
+		"docker-image": "scitran/dcm-convert:v1.1.0"
 	}
 }


### PR DESCRIPTION
When config is provided the field name is not the same as the manifest
('default'), need to account for that case. No longer create metadata file.